### PR TITLE
fix(docker): make deploy/docker/Dockerfile actually build and run

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /app
 
 # Install dependencies
 COPY package*.json ./
+COPY scripts ./scripts
 RUN npm ci --production=false
 
 # Copy app

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:20-alpine
 
+RUN apk add --no-cache bash curl
+
 WORKDIR /app
 
 # Install dependencies


### PR DESCRIPTION
## Summary

Two independent bugs in `deploy/docker/Dockerfile` block every Docker deploy from this file (and any PaaS that builds from it — Coolify, Railway-via-Dockerfile, etc). Both fixes together are needed to get a usable image.

### Bug 1 — `npm ci` fails because `postinstall` can't find its script

The Dockerfile copies only `package*.json` before running `npm ci`, but the `postinstall` hook executes `node scripts/download-pocketbase.js`. At that point `scripts/` is not in the image, so npm aborts:

\`\`\`
> tinykit@0.1.0 postinstall
> svelte-kit sync && node scripts/download-pocketbase.js

Missing Svelte config file in /app — skipping
Error: Cannot find module '/app/scripts/download-pocketbase.js'
\`\`\`

**Fix:** copy `scripts/` before `npm ci`.

### Bug 2 — container crash-loops with `./start.sh: not found`

`deploy/railway/start.sh` has a `#!/bin/bash` shebang and uses bash-specific syntax (`{1..30}` brace expansion, `wait -n`), plus calls `curl` to wait for PocketBase to become healthy. `node:20-alpine` ships neither bash nor curl, so the container fails immediately at runtime:

\`\`\`
/usr/local/bin/docker-entrypoint.sh: exec: line 11: ./start.sh: not found
\`\`\`

This message is misleading — the file exists and is executable. The error is ENOENT on the shebang interpreter (`/bin/bash`).

Switching the shebang to `#!/bin/sh` is not viable because BusyBox `sh` doesn't support the bash features the script uses.

**Fix:** install bash and curl via apk.

## Diff

\`\`\`diff
 FROM node:20-alpine

+RUN apk add --no-cache bash curl
+
 WORKDIR /app

 # Install dependencies
 COPY package*.json ./
+COPY scripts ./scripts
 RUN npm ci --production=false
\`\`\`

## Verified

Built and ran the image locally on linux/arm64. Container starts cleanly:

\`\`\`
Starting tinykit...
Starting Pocketbase...
Pocketbase is ready!
Superuser ready!
Starting SvelteKit server...
Listening on http://0.0.0.0:3000
\`\`\`

`GET /tinykit` → HTTP 200.

## Test plan

- [ ] `docker build -f deploy/docker/Dockerfile -t tinykit .` completes
- [ ] Container starts without entering a restart loop
- [ ] `GET /tinykit` returns 200