### PR TITLE
fix(docker): install bash and curl on alpine for start.sh

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /app
 
 # Install dependencies
 COPY package*.json ./
+COPY scripts ./scripts
 RUN npm ci --production=false
 
 # Copy app

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:20-alpine
 
+RUN apk add --no-cache bash curl
+
 WORKDIR /app
 
 # Install dependencies


### PR DESCRIPTION
## Summary

`deploy/railway/start.sh` has a `#!/bin/bash` shebang and uses bash-specific syntax — `{1..30}` brace expansion and `wait -n` — plus it calls `curl` to wait for PocketBase to become healthy. The `node:20-alpine` base image in `deploy/docker/Dockerfile` ships neither `bash` nor `curl`, so the container fails immediately at runtime with:

```
/usr/local/bin/docker-entrypoint.sh: exec: line 11: ./start.sh: not found
```

This is misleading — the file exists and is executable. The error is ENOENT on the shebang interpreter (`/bin/bash`), reported by the shell as the script itself being missing. Docker keeps restarting the container until you give up.

## Fix

```diff
 FROM node:20-alpine

+RUN apk add --no-cache bash curl

 WORKDIR /app
```

Switching the shebang to `#!/bin/sh` is not an option because the script depends on bash features that BusyBox `sh` doesn't support.

## Verified

Built and ran the image locally on linux/arm64. Container starts cleanly:

```
Starting tinykit...
Starting Pocketbase...
Pocketbase is ready!
Superuser ready!
Starting SvelteKit server...
Listening on http://0.0.0.0:3000
```

`GET /tinykit` returns HTTP 200.

## Related

Stacks on top of #8 — both fixes are needed for any successful Docker deploy from `deploy/docker/Dockerfile`. They are independent bugs but the build is blocked by #8 first and runtime is blocked by this one second.

## Test plan

- [ ] `docker build -f deploy/docker/Dockerfile -t tinykit .` completes
- [ ] `docker run` starts PocketBase and SvelteKit without restart loop
- [ ] `GET /tinykit` returns 200